### PR TITLE
Add Taxonomies overview feature

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -5,6 +5,10 @@ SilverStripe\Admin\ModelAdmin:
   extensions:
     - Chrometoaster\AdvancedTaxonomies\Extensions\LeftAndMainTaxonomyExtension
 
+SilverStripe\Control\Director:
+  rules:
+    at-taxonomy-overview: Chrometoaster\AdvancedTaxonomies\Controllers\TaxonomyOverviewController
+
 ---
 Only:
   moduleexists: 'silverstripe/cms'

--- a/client/style.css
+++ b/client/style.css
@@ -58,12 +58,13 @@
 }
 
 /* style for a link with .at-link-external */
-a.at-link-external {
+.at-link-external {
     padding-right: 1em;
     background-image: url(./img/icons/external-icon--blue.svg);
     background-repeat: no-repeat;
     background-position: 100%;
     background-size: .75em .75em;
+    text-decoration: underline;
 }
 
 /* Mobile view fixing for GridField that lists TaxonomyTerm */

--- a/src/Controllers/TaxonomyOverviewController.php
+++ b/src/Controllers/TaxonomyOverviewController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Chrometoaster\AdvancedTaxonomies\Controllers;
+
+use Chrometoaster\AdvancedTaxonomies\Models\TaxonomyTerm;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\View\ArrayData;
+
+/**
+ * Class TaxonomyDirectoryController
+ *
+ * Controller for returning a list of pages tagged with a specific Taxonomy Term
+ */
+class TaxonomyOverviewController extends Controller
+{
+    private static $url_handlers = [
+        '$ParentID' => 'index',
+    ];
+
+    private static $allowed_actions = [
+        'index',
+    ];
+
+
+    /**
+     * Render a hierarchy
+     *
+     * @param HTTPRequest $request
+     * @return \SilverStripe\ORM\FieldType\DBHTMLText
+     */
+    public function index(HTTPRequest $request)
+    {
+        $parentID = (int) $request->param('ParentID'); // empty param is the same as 0 for the sake of this report
+
+        $terms = TaxonomyTerm::get()->filter(['ParentID' => $parentID]);
+
+        $parentTerm = null;
+        if ($parentID) {
+            $parentTerm = TaxonomyTerm::get()->byID($parentID);
+        }
+
+        return $this->customise(ArrayData::create([
+            'Terms'      => $terms,
+            'ParentTerm' => ($parentTerm && $parentTerm->exists()) ? $parentTerm : false,
+        ]))->renderWith(self::class);
+    }
+}

--- a/src/Extensions/DataObjectTaxonomiesDataExtension.php
+++ b/src/Extensions/DataObjectTaxonomiesDataExtension.php
@@ -3,6 +3,7 @@
 namespace Chrometoaster\AdvancedTaxonomies\Extensions;
 
 use Chrometoaster\AdvancedTaxonomies\Forms\GridFieldAddTagsAutocompleter;
+use Chrometoaster\AdvancedTaxonomies\Forms\GridFieldInfoLink;
 use Chrometoaster\AdvancedTaxonomies\Forms\GridFieldOrderableRows;
 use Chrometoaster\AdvancedTaxonomies\Models\DataObjectTaxonomyTerm;
 use Chrometoaster\AdvancedTaxonomies\Models\TaxonomyTerm;
@@ -76,6 +77,10 @@ class DataObjectTaxonomiesDataExtension extends DataExtension
         $components->removeComponentsByType(GridFieldAddExistingAutocompleter::class);
         $components->addComponent(
             $addExisting = new GridFieldAddTagsAutocompleter('buttons-before-left')
+        );
+
+        $components->addComponent(
+            new GridFieldInfoLink('buttons-before-left', '/at-taxonomy-overview', "Open 'All taxonomies' overview")
         );
 
         $components->getComponentByType(GridFieldDataColumns::class)->setDisplayFields(

--- a/src/Extensions/FileFormFactoryTaxonomyExtension.php
+++ b/src/Extensions/FileFormFactoryTaxonomyExtension.php
@@ -8,6 +8,7 @@ use SilverStripe\AssetAdmin\Forms\AssetFormFactory;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TreeMultiselectField;
 
@@ -54,10 +55,15 @@ class FileFormFactoryTaxonomyExtension extends Extension
                     ->setEmptyString('Add tags by name')
                     ->setShowSearch(true);
 
-                $fields->addFieldToTab(
-                    'Editor.Tags',
-                    $tags
+                $taxonomiesOverviewLink = LiteralField::create(
+                    'TaxonomiesOverviewLink',
+                    '<a href="/at-taxonomies-overview" target="_blank" class="at-link-external">Open \'All taxonomies\' overview</a>'
                 );
+
+                $fields->addFieldsToTab('Editor.Tags', [
+                    $tags,
+                    $taxonomiesOverviewLink,
+                ]);
             }
         }
     }

--- a/src/Forms/GridFieldInfoLink.php
+++ b/src/Forms/GridFieldInfoLink.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Chrometoaster\AdvancedTaxonomies\Forms;
+
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_HTMLProvider;
+use SilverStripe\View\ArrayData;
+
+/**
+ * A button that contains a link to additional information
+ */
+class GridFieldInfoLink implements GridField_HTMLProvider
+{
+    /**
+     * Gridfield fragment
+     *
+     * @var string
+     */
+    protected $targetFragment;
+
+    /**
+     * Destination URL
+     *
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * Button label
+     *
+     * @var string
+     */
+    protected $caption;
+
+
+    /**
+     * GridFieldInfoLink constructor.
+     *
+     * @param string $targetFragment
+     * @param string $url
+     * @param string $label
+     */
+    public function __construct(string $targetFragment, string $url, string $label)
+    {
+        $this->targetFragment = $targetFragment;
+        $this->url            = $url;
+        $this->label          = $label;
+    }
+
+
+    /**
+     * @param GridField $gridField
+     * @return array
+     */
+    public function getHTMLFragments($gridField)
+    {
+        $fragment = ArrayData::create([
+            'Url'   => $this->url,
+            'Label' => $this->label,
+        ])->renderWith(self::class);
+
+        return [$this->targetFragment => $fragment];
+    }
+}

--- a/src/Models/TaxonomyTerm.php
+++ b/src/Models/TaxonomyTerm.php
@@ -37,6 +37,7 @@ use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Versioned\GridFieldArchiveAction;
 use SilverStripe\View\ViewableData;
+use SilverStripe\View\ArrayData;
 use UndefinedOffset\SortableGridField\Forms\GridFieldSortableRows;
 
 /**
@@ -689,6 +690,44 @@ class TaxonomyTerm extends DataObject implements PermissionProvider
         $parts[] = $termsDecorator($this);
 
         return implode($separator, $parts);
+    }
+
+
+    /**
+     * Get term depth in the hierarchy
+     *
+     * @param bool $asArrayList
+     * @return int
+     */
+    public function getTermLevel(): int
+    {
+        $level = 0;
+        $term  = $this;
+
+        while ($term->ParentID) {
+            $level++;
+            $term = $term->Parent();
+        }
+
+        return $level;
+    }
+
+
+    /**
+     * Get a list of dummy position indicators for use in templates
+     * to e.g. indent terms or so
+     *
+     * @return ArrayList
+     */
+    public function getTermLevelList(): ArrayList
+    {
+        $list = ArrayList::create([]);
+
+        for ($i = 0; $i < $this->getTermLevel(); $i++) {
+            $list->push(ArrayData::create(['Pos' => $i]));
+        }
+
+        return $list;
     }
 
 

--- a/templates/Chrometoaster/AdvancedTaxonomies/Controllers/TaxonomyOverviewController.ss
+++ b/templates/Chrometoaster/AdvancedTaxonomies/Controllers/TaxonomyOverviewController.ss
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!--[if IE 9]><html class="ie ie9 lt-ie10" lang="en"><![endif]-->
+<!--[if !IE]><!-->
+<html lang="en"><!--<![endif]-->
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Advanced Taxonomies overview</title>
+
+    <style>
+        table {
+            border-collapse: collapse;
+        }
+
+        thead {
+            background-color: #eee;
+        }
+
+        th, td {
+            border: 1px solid #ccc;
+            text-align: left;
+            padding: 4px;
+        }
+    </style>
+</head>
+
+<body>
+<h1>Taxonomies overview</h1>
+    <% if $ParentTerm %><p>Parent term: <strong>{$ParentTerm.Title}</strong></p><% end_if %>
+
+    <% include Chrometoaster\AdvancedTaxonomies\Controllers\TaxonomyOverviewController_Terms %>
+</body>
+
+</html>

--- a/templates/Chrometoaster/AdvancedTaxonomies/Controllers/TaxonomyOverviewController_TermRow.ss
+++ b/templates/Chrometoaster/AdvancedTaxonomies/Controllers/TaxonomyOverviewController_TermRow.ss
@@ -1,0 +1,14 @@
+<% loop $Terms.Sort('Sort') %>
+    <tr>
+        <% if $TermLevel == 0 %>
+        <td><strong>{$Name}</strong></td>
+        <% else %>
+        <td><% loop $TermLevelList %> - <% end_loop %>{$Name}</td>
+        <% end_if %>
+        <td>{$Description}</td>
+        <td>{$AuthorDefinition}</td>
+    </tr>
+    <% if $Children.count %>
+        <% include Chrometoaster\AdvancedTaxonomies\Controllers\TaxonomyOverviewController_TermRow Terms=$Children %>
+    <% end_if %>
+<% end_loop %>

--- a/templates/Chrometoaster/AdvancedTaxonomies/Controllers/TaxonomyOverviewController_Terms.ss
+++ b/templates/Chrometoaster/AdvancedTaxonomies/Controllers/TaxonomyOverviewController_Terms.ss
@@ -1,0 +1,12 @@
+<table>
+    <thead>
+    <tr>
+        <th>Term</th>
+        <th>Description</th>
+        <th>Author definition</th>
+    </tr>
+    </thead>
+    <tbody>
+        <% include Chrometoaster\AdvancedTaxonomies\Controllers\TaxonomyOverviewController_TermRow %>
+    </tbody>
+</table>

--- a/templates/Chrometoaster/AdvancedTaxonomies/Forms/GridFieldInfoLink.ss
+++ b/templates/Chrometoaster/AdvancedTaxonomies/Forms/GridFieldInfoLink.ss
@@ -1,0 +1,5 @@
+<a class="btn btn-secondary" href="{$Url.ATT}" target="_blank">
+    <span class="btn__title">
+        <span class="at-link-external">{$Label.XML}</span>
+    </span>
+</a>


### PR DESCRIPTION
Linked from the tagging interface (gridfield or treemultiselect), the simple table gives content authors a global overview of all taxonomies, their hierarchies, titles and descriptions.