### PR TITLE
Fix filtering based on InternalOnly flag for displayable tags

### DIFF
--- a/src/Extensions/DataObjectTaxonomiesDataExtension.php
+++ b/src/Extensions/DataObjectTaxonomiesDataExtension.php
@@ -193,6 +193,6 @@ class DataObjectTaxonomiesDataExtension extends DataExtension
      */
     public function getDisplayableTags()
     {
-        return $this->getOwner()->Tags()->filter('InternalOnly', false);
+        return $this->getOwner()->Tags()->filter(['Type.InternalOnly' => false]);
     }
 }


### PR DESCRIPTION
As `InternalOnly` flag is defined for the type rather than the term itself, use the type in the ORM filter when collating displayable tags.