### PR TITLE
Feature to make the presentation of a taxonomy term be configurable in CMS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "silverstripe/framework": "^4",
     "silverstripe/versioned": "^1",
     "silverstripe/vendor-plugin": "^1",
-    "symbiote/silverstripe-gridfieldextensions": "^3.2.3"
+    "symbiote/silverstripe-gridfieldextensions": "^3.2.3",
+    "unclecheese/display-logic": "^2.0"
   },
   "extra": {
     "expose": [

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -8,6 +8,7 @@ en:
     URLSegment: "A unique identifier used by the CMS (e.g. in URL filter parameters), which must be unique across all terms, taxonomies, concept classes. It will be automatically generated from <i><b>Name</b></i>, if left blank. Use lower case, URL-safe characters, no spaces. Avoid parentheses. Required."
     Title: "This singular term is displayed to the public — often as a tag. The <i><b>Display name singular</b></i> will be the same or similar to the <i><b>Name</b></i> (though possibly longer) and will be automatically generated from the <i><b>Name</b></i>, if left blank. Avoid parentheses. Required."
     TitlePlural: "This term is displayed to the public when the context requires a pluralised label. It will be automatically generated from <i><b>Name</b></i>, if left blank. Avoid parentheses. Required."
+    TitleCustom: "When provided, the custom display name overrides both singular and plural display names when displayed to the public."
     Description: "The short reference description shown within the CMS"
     AuthorDefinition: "Shown to authors and admins; a brief definition about the purpose of the term for those who create and edit taxonomies."
     PublicDefinition: "Shown to users on the front-end; a brief definition of the term for those who view taxonomy terms as tags or filters."

--- a/src/Models/BaseObject.php
+++ b/src/Models/BaseObject.php
@@ -67,7 +67,7 @@ class BaseObject extends DataObject implements PermissionProvider
     /**
      * Get a text from the translations system for a given identifier
      *
-     * Looks up the string for the extending/current class and uses this class strings as a fallback.
+     * Looks up the string for the extending/current class and recursively uses the parent class strings as a fallback.
      * Supports sprintf evaluation of extra params to replace in the text.
      *
      * @param string $identifier
@@ -75,7 +75,13 @@ class BaseObject extends DataObject implements PermissionProvider
      */
     protected function _t(string $identifier, ...$params): string
     {
-        $text = trim(trim(_t(static::class . '.' . $identifier)) ?: _t(self::class . '.' . $identifier));
+        $class = static::class;
+        $text  = '';
+
+        while (!$text && $class !== DataObject::class) {
+            $text  = trim(_t($class . '.' . $identifier));
+            $class = get_parent_class($class);
+        }
 
         return sprintf($text, ...$params);
     }

--- a/src/Models/BaseTerm.php
+++ b/src/Models/BaseTerm.php
@@ -22,6 +22,7 @@ class BaseTerm extends BaseObject
     private static $db = [
         'Title'            => 'Varchar(255)',
         'TitlePlural'      => 'Varchar(255)',
+        'TitleCustom'      => 'Varchar(255)', // used from TaxonomyTerm, but data-wise belongs here
         'Description'      => 'Text',
         'AuthorDefinition' => 'Text',
         'PublicDefinition' => 'Text',
@@ -66,6 +67,7 @@ class BaseTerm extends BaseObject
         $this->i18nDisableWarning();
 
         $fields = parent::getCMSFields();
+        $fields->removeByName(['TitleCustom']); // field is used from TaxonomyTerm level only
 
         // Add description to fields
         $fields->datafieldByName('Title')->setDescription($this->_t('Title'));


### PR DESCRIPTION
- Add DB fields for customising which title field should be used for present
- Require display-logic module for CMS fields displaying conditionally
  