### PR TITLE
Update fixture YML file to add missing defined object

### DIFF
--- a/tests/TaxonomyTerm.yml
+++ b/tests/TaxonomyTerm.yml
@@ -115,6 +115,8 @@ Chrometoaster\AdvancedTaxonomies\Tests\Models\OwnerObject:
     Title: 'Data object 4'
   object5:
     Title: 'Data object 5'
+  object6:
+    Title: 'Data object 6'
 
 
 Chrometoaster\AdvancedTaxonomies\Models\DataObjectTaxonomyTerm:


### PR DESCRIPTION
an owner object is required in test cases with identifier 'object6', but not being defined in the fixture YML filel